### PR TITLE
Investigate using black-box dynamics in neural CLBF

### DIFF
--- a/neural_clbf/systems/control_affine_system.py
+++ b/neural_clbf/systems/control_affine_system.py
@@ -357,6 +357,7 @@ class ControlAffineSystem(ABC):
         """
         return self.sample_with_mask(num_samples, self.boundary_mask, max_tries)
 
+    @torch.no_grad()
     def control_affine_dynamics(
         self, x: torch.Tensor, params: Optional[Scenario] = None
     ) -> Tuple[torch.Tensor, torch.Tensor]:


### PR DESCRIPTION
Goal: figure out whether the neural CLBF controller requires propagating gradients through the dynamics (since this is not possible when replacing with black-box dynamics.) 

A simple A/B test with gradients on and off respectively should be enough of a sanity check